### PR TITLE
Fix prevPath reference

### DIFF
--- a/src/components/layouts/method-layout.js
+++ b/src/components/layouts/method-layout.js
@@ -88,7 +88,9 @@ function MethodLayout({ data, location }) {
       })
   )
 
-  const { state: { prevPath, prevPage } = {} } = location
+  // Get previous page path, if available
+  let prevPath = location.state && location.state.prevPath || ""
+  let prevPage = location.state && location.state.prevPage || ""
 
   // Fix images URL by adding app root url with prefix
   const sections = mapValues(frontmattermd, section => {
@@ -111,7 +113,7 @@ function MethodLayout({ data, location }) {
               <MoreLink
                 direction="back"
                 to={
-                  prevPath?.startsWith("/guide-builder")
+                  prevPath.startsWith("/guide-builder")
                     ? prevPage
                     : "/#allMethods"
                 }


### PR DESCRIPTION
If page reload is executed on any method an error will be thrown because `location.state` is undefined. To test if this is working properly:

- Go to home page, enter on any method, execute a page reload, no error should be thrown and back button should read "Back to All Methods"
- Go to Guide Builder, click on any method "Read More", the back button must read "Back to Guide Builder"