### PR TITLE
Remove <pre> negative text-indent in square lists

### DIFF
--- a/src/styles/type/lists.js
+++ b/src/styles/type/lists.js
@@ -62,6 +62,9 @@ export const SquareUl = styled.ul`
       text-indent: -1.8rem;
     }
   }
+  pre {
+    text-indent: 0;
+  }
   table {
     margin: 2rem 0;
     font-size: 0.875rem;


### PR DESCRIPTION
Affects a very small change in preformatted text code blocks in `<SquareUL>` styled component