### PR TITLE
Datestamp generated guide

### DIFF
--- a/src/helpers/generate-guide.js
+++ b/src/helpers/generate-guide.js
@@ -509,7 +509,7 @@ export default async function generateGuide(md, guideTitle) {
 
   // Create stream
   const stream = doc.pipe(blobStream())
-
+  const todaysDate = new Date().toISOString().slice(0, 10)
   // Add content
   await render(doc, md)
 
@@ -545,6 +545,6 @@ export default async function generateGuide(md, guideTitle) {
   doc.end()
 
   return await stream.on("finish", function () {
-    saveAs(stream.toBlob("application/pdf"), `Safetag - ${guideTitle}.pdf`)
+    saveAs(stream.toBlob("application/pdf"), `Safetag-${guideTitle}_${todaysDate}.pdf`)
   })
 }


### PR DESCRIPTION
This pr adds a date to the generated guide title. This is one approach to providing auditors with visibility on the freshness of the guide. 

An alternative approach, to be coordinated with the new static guide introduced in #443, would be to version each guide - both the PDF, and the repo (which I believe is already done). A `version` or `last updated` field could also be added to the method and/or activity page on the site.