### PR TITLE
Fix activity approach icons

### DIFF
--- a/src/components/layouts/activity-layout.js
+++ b/src/components/layouts/activity-layout.js
@@ -119,7 +119,7 @@ function ActivityLayout({ data }) {
                 <Dl boldDesc>
                   <dt>Approach</dt>
                   {frontmatter.approaches.map(approach => (
-                    <dd key={approach}>{approach}<img src={`/img/${approach}_icon.png`} /></dd>
+                    <dd key={approach}>{approach}<img src={`/img/${approach.toLowerCase()}_icon.png`} /></dd>
                   ))}
                   <dt>Authors</dt>
                   <dd>{frontmatter.authors}</dd>

--- a/src/components/layouts/activity-layout.js
+++ b/src/components/layouts/activity-layout.js
@@ -43,11 +43,14 @@ const ActivityPage = styled(Inpage)`
   ${Dl} {
     dd {
       display: flex;
-      align-items: center;
       img {
         max-width: 1.75rem;
-        margin-left: 1rem;
-        margin-bottom: 0.5rem;
+        margin-right: 1rem;
+        order: -1;
+
+      }
+      + dd {
+        margin-top: 0;
       }
     }
   }


### PR DESCRIPTION
Activity approach icons are broken in production:
<img src="https://user-images.githubusercontent.com/12634024/104410834-23f8c400-5537-11eb-8cb2-d58984da2ef9.png" width="280px">

This fix ensures that the image source name in the html matches the actual file name. Strangely, this did not error on local development or locally served builds.