### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/en/document_matter/CODE_OF_CONDUCT.md
+++ b/en/document_matter/CODE_OF_CONDUCT.md
@@ -6,11 +6,11 @@ What we do: The community collaborates actively to share knowledge, build capaci
 
 ### Community Standards
 
-The SAFETAG Community of Practice (SCoP) will a be a closed and private group, initially housed within the existing orgsec.community listserv.
+The SAFETAG Community of Practice (SCoP) exists in both public and private groups, currently found including a public Slack channel, the Internet Freedom Festival Mattermost, and the orgsec.community listserv.
 
-* Community members are encouraged to be active - positively contributing / leading discussions on community channels, creating, curating, or peer-reviewing content or contributing to the issue queue. There will be an annual "introduction" thread on the listserv where all SCoP members are expected to respond with a short note on current (shareable) activities.
+* Community members are encouraged to be active - positively contributing / leading discussions on community channels, creating, curating, or peer-reviewing content or contributing to the issue queue. 
 * Some SCoP members may have privacy concerns, and should join the community using a pseudonym they are comfortable with engaging online in both public and private spaces with.
-* Joining the community: While housed within the orgsec.community, the SCoP will follow the joining process on that list.
+* Joining the community: Directions for joining the SAFETAG Slack can be found on https://www.safetag.org; for joining the Internet Freedom Mattermost can be found at https://internetfreedomfestival.org/wiki/index.php/IFF_Mattermost.
 * The SCoP is responsible for adhering to the SAFETAG Code of Conduct, below
 
 #### SAFETAG Code of Conduct
@@ -24,41 +24,12 @@ Members of the SAFETAG community are expected to:
 * Perform your job responsibly and well. Ask and consult with fellow members of the community.
 * Respect other members of the community as peers and promote a safe, inclusive, and harassment-free environment
 
-#### Community Manager
+### Code of Conduct Violations
 
-There will be, given that funds are available, a paid **community manager** who has at least a quarter of their time to support the SAFETAG community and contribute to and support the broader community around NGO organizational security.  This community manager should rotate among organizations implementing substantial organizational security work. There may be gaps and/or overlaps due to project and staff funding requirements; it is important for implementing organizations to coordinate funding this position in order to minimize this.
-
-The CM's role is to cultivate, support, and grow the community.  This includes, but is not limited to:
-
-* Proposing, planning, and facilitating discussions to support a vibrant and active community
-* To a reasonable degree and avoiding conflicts of interest, supporting and coordinating fundraising work across the community
-* Providing transparency to the work being done across the implementing community, including the sharing of any requests for audits.
-* Shepherding and supporting the creation of new content (managing peer review, managing pull requests, providing guidance and direct support on merging content into the SAFETAG architecture)
-* Supporting the ongoing development of the SAFETAG mission, vision, code of conduct, licensing, and related "meta" content.
-* Managing the technical infrastructure (website, content repository)
-* Providing at least quarterly reports to the community summarizing activity such as new content, supporting tools or interfaces, new opportunities, and new members
-* Scheduling and joining Advisory Board meetings to participate as well as take notes as relevant.
-* Documenting the activities, duties, and challenges for future community managers.
-
-### The Advisory Board
-
-#### Structure
-
-* An **Advisory Board** of no more than 10 and no fewer than 3 persons shall be made of individuals and institutional representatives, nominated by the board.
-* Board members are to serve 18 month terms; 2 consecutive term limit. Institutions are not term limited, but are encouraged to change their representation to the Board when representatives have served two consecutive terms, and are expected to step down if they are unable to continue contributions defined below.
-* There can be up to four institutional members of the board, representing organisations that have a vested interest in SAFETAG, due to using it extensively in their own programs. Institutions should designate a representative with a relevant program role and experience with organizational security. Institutional members of the Board are expected to significantly contribute, through funding the community manager, significant content contributions, infrastructure or activities.
-* Board members, including institutions, will be appointed and dismissed by simple majority of votes cast by board members with a voting window of two weeks.
-* Board meetings over calls or in person ought to be minuted, the board chair is responsible for identifying a note taker.
-* Board members who do not participate in voting processes and fail to join 2 consecutive board calls without excusing themselves in advance to the board are automatically removed from the board and trigger the voting in of a new member
-
-#### Responsibilities
-
-* The Board is responsible for the stewardship of the SAFETAG framework and supporting and advising the CM.
-* The Board is responsible for ensuring that the responsibilities of a CM are performed, whether completely by the CM, by a combination of CM and Board members, or by Board members during gaps in the CM role, as well as measuring the performance of the CM
-* The Board will be responsible for proposing changes to these governance rules, through simple majority voting
-* All members of the Board will provide an ombudsman service to sensitively manage ethics concerns regarding the community manager, fellow board members, and usage of the SAFETAG framework and trademark more broadly
+* Serious or repeated violations of the Code of Conduct may lead to removal from one or all community platforms.
+* To report a violation, please reach out privately to an administrative user of the relevant platform or email info at safetag.org
 
 ### Contact
 
-For SAFETAG content related questions, please file an issue: https://github.com/SAFETAG/SAFETAG/issues
-You can email the SAFETAG Advisory Board at AdvisoryBoard at safetag.org
+For SAFETAG content related questions, please file an issue: https://github.com/SAFETAG/SAFETAG/issues.
+You can email the SAFETAG Coordinators at info at safetag.org

--- a/en/document_matter/CODE_OF_CONDUCT.md
+++ b/en/document_matter/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ What we do: The community collaborates actively to share knowledge, build capaci
 
 ### Community Standards
 
-The SAFETAG Community of Practice (SCoP) exists in both public and private groups, currently found including a public Slack channel, the Internet Freedom Festival Mattermost, and the orgsec.community listserv.
+The SAFETAG Community of Practice (SCoP) exists in both public and private groups, currently including a public Slack channel, the Internet Freedom Festival Mattermost, and the orgsec.community listserv.
 
 * Community members are encouraged to be active - positively contributing / leading discussions on community channels, creating, curating, or peer-reviewing content or contributing to the issue queue. 
 * Some SCoP members may have privacy concerns, and should join the community using a pseudonym they are comfortable with engaging online in both public and private spaces with.


### PR DESCRIPTION
Updated information on existing community forums and options for joining. Added information on consequences and reporting procedure for violations. Proposing to remove Community Manager and Advisory Board text until revisited, at which point they can go into a separate governance file in order to keep Code of Conduct focused.